### PR TITLE
Add possibility to describe ions with a Formula object

### DIFF
--- a/molmass/elements.py
+++ b/molmass/elements.py
@@ -111,6 +111,22 @@ class lazyattr:
             return getattr(super(owner, instance), self.func.__name__)
         setattr(instance, self.func.__name__, result)
         return result
+        
+        
+class Particle(object):
+    """Particle like electron of proton
+    
+    Attributes
+    ----------
+    mass : float
+        Relative mass. Ratio of the average mass of atoms
+        of the element to 1/12 of the mass of an atom of 12C
+    charge : float
+        charge in Coulombs.
+    """
+    
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
 
 
 class Element:
@@ -347,21 +363,39 @@ class Element:
 class Isotope:
     """Isotope massnumber, relative atomic mass, and abundance."""
 
-    __slots__ = ('massnumber', 'mass', 'abundance')
+    __slots__ = ('massnumber', 'mass', 'abundance', 'charge')
 
-    def __init__(self, mass=0.0, abundance=1.0, massnumber=0):
+    def __init__(self, mass=0.0, abundance=1.0, massnumber=0, charge=0):
         self.mass = mass
         self.abundance = abundance
         self.massnumber = massnumber
+        self.charge = charge
+        
+    @property
+    def mz(self):
+        """Return monoisotopic mass corrected by ion charge."""
+        if self.charge != 0:
+            return (self.mass - ELECTRON.mass * self.charge) / abs(self.charge)
+        return self.mass
 
     def __str__(self):
-        return '{}, {:.4f}, {:.6f}%'.format(
+        s = '{}, {:.4f}, {:.6f}%'.format(
             self.massnumber, self.mass, self.abundance * 100
         )
+        if self.charge == 1:
+            s += ', +'
+        elif self.charge == -1:
+            s += ', -'
+        elif self.charge > 0:
+            s += ', {}+'.format(self.charge)
+        elif self.charge < 0:
+            s += ', {}-'.format(-self.charge)
+            
+        return s
 
     def __repr__(self):
-        return 'Isotope({}, {}, {})'.format(
-            repr(self.mass), repr(self.abundance), repr(self.massnumber)
+        return 'Isotope({}, {}, {}, {})'.format(
+            repr(self.mass), repr(self.abundance), repr(self.massnumber), repr(self.charge)
         )
 
 
@@ -2087,6 +2121,12 @@ ELEMENTS = Elements(
         isotopes={276: Isotope(276.15159, 1.0, 276)},
     ),
 )
+
+e = 1.602176634e-19 # Elementary charge in Coulombs
+ELECTRON = Particle(mass=5.48579909065e-4, charge=-e)
+PROTON = Particle(mass=1.007276466621, charge=+e)
+NEUTRON = Particle(mass=1.00866491595, charge=0.)
+POSITRON = POSITON = ANTIELECTRON = Particle(mass=5.48579909065e-4, charge=+e)
 
 PERIODS = {1: 'K', 2: 'L', 3: 'M', 4: 'N', 5: 'O', 6: 'P', 7: 'Q'}
 


### PR DESCRIPTION
This PR adds the possibility to add charges to formula objects, like this:

```python
>>> Formula("C5H14NO+")
Formula('[C5H14NO]+')
>>> Formula("C5H14NO+").charge
1
>>> def _(spectrum):
         max_val = max([val[1] for val in spectrum.values()])
         for key, val in spectrum.items():
             print(f'{key}, {val[0]:.6f}, {val[1]/max_val*100:.6f}%')
>>> _(Formula("C5H14NO+").spectrum())
104, 104.106990, 100.000000%
105, 105.110043, 5.972305%
106, 106.111988, 0.353913%
107, 107.114511, 0.014170%
108, 108.117331, 0.000315%
109, 109.120178, 0.000004%
110, 110.123193, 0.000000%
>>> Formula("SO4_2-")
Formula('[SO4]2-')
>>> Formula('[SO4]2-').charge
-2
>>> _(Formula("SO4_2-").spectrum())
96, 47.976413, 100.000000%
97, 48.476498, 0.941927%
98, 48.974968, 5.297443%
99, 49.477523, 0.014247%
100, 49.976118, 0.049850%
101, 50.478593, 0.000080%
102, 50.977559, 0.000203%
103, 51.479728, 0.000000%
104, 51.979089, 0.000000%
105, 52.480272, 0.000000%
106, 52.980286, 0.000000%
```