### PR TITLE
Fixed the  call issue in formulas with multiple isotopes of same element

### DIFF
--- a/molmass/molmass.py
+++ b/molmass/molmass.py
@@ -827,10 +827,11 @@ class Formula:
                     count = iso[massnumber]
                     if massnumber:
                         mass = ele.isotopes[massnumber].mass * count
-                        symbol = f'{massnumber}{symbol}'
+                        symbol_iso = f'{massnumber}{symbol}'
                     else:
                         mass = ele.mass * count
-                    result.append((symbol, count, mass, mass / self.mass))
+                        symbol_iso = symbol
+                    result.append((symbol_iso, count, mass, mass / self.mass))
         else:
             for symbol in hill_sorted(elements):
                 ele = ELEMENTS[symbol]


### PR DESCRIPTION
I believe there was a bug for calls to `composition()` for formulas having multiple isotopes of the same element. For example `C16H9[79Br][81Br]N2O2`.  The formula is parsed correctly during ingestion, but during the `composition` call, there are two runs of the `for massnumber in sorted(iso)` loop during evaluation of the `Br` element since there are two isotopes. On the first run (isotope 79), `symbol` is overwritten to be `79Br` but on the second run (isotope 81) this overwritten value of `symbol` gets overwritten again to `8179Br` resulting in an incorrect symbol in the final composition output. 

Introduced the variable `symbol_iso` to avoid intermediate overwrite issues in this loop.